### PR TITLE
Update composer definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "illuminate/session": "5.2.*",
+        "illuminate/session": "^5.2",
         "php": ">=5.5.9"
     },
     "autoload": {


### PR DESCRIPTION
Fix `illuminate/session` version to `^5.2`, same as the other illuminate packages loaded in the core Sprinkle. This allows to load the latest version containing the fix for session on php 7.